### PR TITLE
Bug en el toggle del navbar arreglado 

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -55,31 +55,21 @@ body, html {
 }
 
 
-.navbar{
-    max-height: 100px;
-    width: 100%;
-    z-index: 1000; /* Ajusta el índice z para que esté por encima de otros elementos */
-}
+/* modificar la clase navbar directamente sobreescribe las clases predefinidas en bootstrap
+fue eso lo que causaba el bug que impedia que el collapse se muestre adecuadamente */
 
 .navbar img {
     width: 100px; /* Ajusta el ancho según tus preferencias */
     height: auto;
 }
-.navbar{
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    width: 100%;
-    z-index: 1000;
-    max-height: 100px;
-}
+
 .navbar .navbar-brand {
     display: flex;
     align-items: center;
 }
 .navbar .navbar-nav .nav-item {
     margin-right: 20px; /* Ajusta el espacio entre los elementos, según tus preferencias */
+    font-size: larger;
 }
 .section1{
     width: 100%;

--- a/index.html
+++ b/index.html
@@ -21,14 +21,16 @@
       <a class="navbar-brand" href="#">
         <img src="/images/LogoFondoBlanco.png" width="100" height="100" alt="">
       </a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
-        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+       data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" 
+       aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
-        <ul class="navbar-nav">
+      <div class="collapse navbar-collapse text-md-left" id="navbarSupportedContent">
+        <!-- El id de navbarSupportedContent es lo que hace que el toggle funcione en pantallas de moviles -->
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0 ">
           <li class="nav-item">
-            <a class="nav-link" aria-current="page" href="#">Servicios</a>
+            <a class="nav-link active" aria-current="page" href="#">Servicios</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Sobre nosotros</a>


### PR DESCRIPTION
Al cambiar el id del contenedor que contenia los enlaces del navbar el toggle para las pantallas moviles quedaba inservible, y tambien al intentar modificar la clase navbar directamente (.navbar{}) el collapse del toggle eliminaba el fondo blanco que se desplegaba lo que dificultaba la legibilidad del texto, pero todavia se pueden modificar las clases que contengan a navbar (.navbar nav-item {} por ejemplo), fuera de eso ni puta idea de que poner en la section, preferiria que le hagamos focus a los enlaces del navbar, hacemos que lleven a una pagina cada uno? la parte de contactos podria no hacer eso y en su lugar desplegar enlaces de algun correo electronico y numero de wathsapp    